### PR TITLE
follow up to issue #37 and spec file corrections to be more widely usable

### DIFF
--- a/packaging/RPM/squidanalyzer.spec
+++ b/packaging/RPM/squidanalyzer.spec
@@ -3,13 +3,15 @@
 Summary:	Squid proxy log analyzer and report generator
 Name:		squidanalyzer
 Version:	5.3
-Release:	%mkrel 1
+Release:	1
 License:	GPLv3
 Group:		Monitoring
 URL:		http://%{name}.darold.net/
 Source:		http://prdownloads.sourceforge.net/squid-report/%{name}-%{version}.tar.gz
 BuildRequires:	perl
 BuildArch:	noarch
+
+Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n) 
 
 %description
 Squid proxy native log analyzer and reports generator with full
@@ -29,6 +31,9 @@ or more often with heavy proxy usage.
 
 %build
 perl Makefile.PL DESTDIR=%{buildroot} LOGFILE=%{_logdir}/squid/access.log BINDIR=%{_sbindir} HTMLDIR=%{contentdir}/html/%{name} BASEURL=/%{name} MANDIR=%{_mandir}/man3 QUIET=yes
+
+# remove special files
+find %{buildroot} -name "perllocal.pod" -o -name ".packlist" |xargs -i rm -f {}
 
 make
 


### PR DESCRIPTION
As asked in https://github.com/darold/squidanalyzer/issues/37
- Setting group owner to root since squid group may not exist (and this ownership is not needed)
- Replace macros specific to initial contributor distro (%mkrel, %make, %makeinstall_std) by more standard commands
- add a BuildRoot macro (needed by RHEL). Note that the macro may be replaced by a distro specific one (Fedora does it)
-  add a "find | rm" to remove "perllocal.pod" and ".packlist" files which should not be packaged
