### PR TITLE
Add feature to mention date range for reports.

### DIFF
--- a/README
+++ b/README
@@ -164,6 +164,8 @@ USAGE
         -h | --help                : show this message and exit.
         -j | --jobs number         : number of jobs to run at same time. Default
                                      is 1, run as single process.
+        -o | --outputdir name      : set output directory. If it does not start
+                                     with / then prefixes Output from configfile
         -p | --preserve number     : used to set the statistic obsolescence in
                                      number of month. Older stats will be removed.
         -P | --pid_dir directory   : set directory where pid file will be stored.
@@ -180,6 +182,8 @@ USAGE
         --no-year-stat             : disable years statistics, reports will start
                                      from month level only.
         --no-week-stat             : disable weekly statistics.
+        --startdate YYYYMMDDHHMMSS : log lines before this date and time will not be parsed.
+        --stopdate  YYYYMMDDHHMMSS : log lines after this date and time will not be parsed.
 
     Log files to parse can be given as command line arguments or as a comma
     separated list of file for the LogFile configuration directive. By

--- a/SquidAnalyzer.pm
+++ b/SquidAnalyzer.pm
@@ -100,6 +100,8 @@ my %Translate = (
 	'Denied_help' => 'Objects with denied access',
 	'Cost_help' => '1 Mega byte =',
 	'Generation' => 'Report generated on',
+	'Generation_from' => 'From %s ',
+	'Generation_to' => 'Upto %s',
 	'Main_cache_title' => 'Cache Statistics',
 	'Cache_title' => 'Cache Statistics on',
 	'Stat_label' => 'Stat',
@@ -1322,6 +1324,9 @@ sub _parse_file_part
 		}
 		
 		if ($time) {
+			# end parsing if time range exceeded
+			last if ($self->{history_endtime} && ($time > $self->{history_endtime}));
+
 			# Do not parse some unwanted method
 			my $qm_method = quotemeta($method) || '';
 			next if (($#{$self->{ExcludedMethods}} >= 0) && grep(/^$qm_method$/, @{$self->{ExcludedMethods}}));
@@ -1341,21 +1346,21 @@ sub _parse_file_part
 
 			# Register the last parsing time and last offset position in logfile
 			if (!$self->{is_squidguard_log} && !$self->{is_ufdbguard_log}) {
-				$self->{end_time} = $time if (!$time || ($self->{end_time} < $time));
+				$self->{end_time} = $time if ($self->{end_time} < $time);
 				# Register the first parsing time
 				if (!$self->{begin_time} || ($self->{begin_time} > $time)) {
 					$self->{begin_time} = $time;
 					print STDERR "SQUID LOG SET START TIME: ", strftime("%a %b %e %H:%M:%S %Y", CORE::localtime($time)), "\n" if (!$self->{QuietMode});
 				}
 			} elsif (!$self->{is_squidguard_log}) {
-				$self->{ug_end_time} = $time if (!$time || ($self->{ug_end_time} < $time));
+				$self->{ug_end_time} = $time if ($self->{ug_end_time} < $time);
 				# Register the first parsing time
 				if (!$self->{ug_begin_time} || ($self->{ug_begin_time} > $time)) {
 					$self->{ug_begin_time} = $time;
 					print STDERR "UFDBGUARD LOG SET START TIME: ", strftime("%a %b %e %H:%M:%S %Y", CORE::localtime($time)), "\n" if (!$self->{QuietMode});
 				}
 			} else {
-				$self->{sg_end_time} = $time if (!$time || ($self->{sg_end_time} < $time));
+				$self->{sg_end_time} = $time if ($self->{sg_end_time} < $time);
 				# Register the first parsing time
 				if (!$self->{sg_begin_time} || ($self->{sg_begin_time} > $time)) {
 					$self->{sg_begin_time} = $time;
@@ -1591,6 +1596,7 @@ sub _init
 	}
 
 	$self->{CustomHeader} = $options{CustomHeader} || qq{<a href="$self->{WebUrl}"><img src="$self->{WebUrl}images/logo-squidanalyzer.png" title="SquidAnalyzer $VERSION" border="0"></a> SquidAnalyzer};
+	$self->{CustomTitle} = $options{CustomTitle} || qq{SquidAnalyzer $VERSION Report};
 	$self->{ExcludedMethods} = ();
 	if ($options{ExcludedMethods}) {
 		push(@{$self->{ExcludedMethods}}, split(/\s*,\s*/, $options{ExcludedMethods}));
@@ -1691,6 +1697,9 @@ sub _init
 	$self->{week_parsed} = ();
 	# Used to stored command line parameters from squid-analyzer
 	$self->{history_time} = 0;
+	$self->{history_endtime} = 0;
+	$self->{sg_history_time} = 0;
+	$self->{ug_history_time} = 0;
 	$self->{preserve} = 0;
 	$self->{sg_end_time} = 0;
 	$self->{sg_end_offset} = 0;
@@ -3001,6 +3010,21 @@ sub _print_header
 	$sortpos ||= 2;
 	my $sorttable = '';
 	$sorttable = "var myTH = document.getElementById('contenu').getElementsByTagName('th')[$sortpos]; sorttable.innerSortFunction.apply(myTH, []);";
+	my $reportrange = '';
+	if ($self->{report_starttime} || $self->{report_endtime}) {
+		$reportrange = '<br>';
+		if ($self->{report_starttime}) {
+			my $t1 = $Translate{'Generation_from'};
+			$t1 =~ s/\%s/$self->{report_starttime}/;
+			$reportrange .= $t1;
+		}
+		if ($self->{report_endtime}) {
+			my $t1 = $Translate{'Generation_to'};
+			$t1 =~ s/\%s/$self->{report_endtime}/;
+			$reportrange .= $t1;
+		}
+		$reportrange .= '.';
+	}
 	print $$fileout qq{
 <html>
 <head>
@@ -3011,7 +3035,7 @@ sub _print_header
 <meta HTTP-EQUIV="Generator" CONTENT="SquidAnalyzer $VERSION" />
 <meta HTTP-EQUIV="Date" CONTENT="$now" />
 <meta HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=$Translate{'CharSet'}" />
-<title>SquidAnalyzer $VERSION Report</title>
+<title>$self->{CustomTitle}</title>
 <link rel="stylesheet" type="text/css" href="$self->{WebUrl}squidanalyzer.css" media="screen" />
 <!-- javascript to sort table -->
 <script type="text/javascript" src="$self->{WebUrl}sorttable.js"></script>
@@ -3028,7 +3052,7 @@ sub _print_header
 		$self->{CustomHeader}
 		</h1>
 		<p class="sous-titre">
-		$Translate{'Generation'} $now.
+		$Translate{'Generation'} $now.$reportrange
 		</p>
 		</div>
 		$calendar
@@ -3099,8 +3123,8 @@ sub buildHTML
 	my $p_month = 0;
 	my $p_year = 0;
 	my $p_week = 0;
-	if ($self->{history_time} || $self->{sg_history_time} || $self->{begin_time}) {
-		my @ltime = CORE::localtime($self->{history_time} || $self->{sg_history_time} || $self->{begin_time});
+	if ($self->{history_time} || $self->{sg_history_time} || $self->{ug_history_time} || $self->{begin_time}) {
+		my @ltime = CORE::localtime($self->{history_time} || $self->{sg_history_time} || $self->{ug_history_time} || $self->{begin_time});
 		if ($self->{is_squidguard_log}) {
 			@ltime = CORE::localtime($self->{sg_history_time} || $self->{begin_time});
 		} elsif ($self->{is_ufdbguard_log}) {

--- a/doc/SquidAnalyzer.pod
+++ b/doc/SquidAnalyzer.pod
@@ -168,6 +168,8 @@ Usage: squid-analyzer [ -c squidanalyzer.conf ] [logfile(s)]
     -h | --help                : show this message and exit.
     -j | --jobs number         : number of jobs to run at same time. Default
                                  is 1, run as single process.
+    -o | --outputdir name      : set output directory. If it does not start
+				 with / then prefixes Output from configfile
     -p | --preserve number     : used to set the statistic obsolescence in
 				 number of month. Older stats will be removed.
     -P | --pid_dir directory   : set directory where pid file will be stored.
@@ -184,6 +186,8 @@ Usage: squid-analyzer [ -c squidanalyzer.conf ] [logfile(s)]
     --no-year-stat             : disable years statistics, reports will start
                                  from month level only.
     --no-week-stat             : disable weekly statistics.
+    --startdate YYYYMMDDHHMMSS : log lines before this date and time will not be parsed.
+    --stopdate  YYYYMMDDHHMMSS : log lines after this date and time will not be parsed.
 
 Log files to parse can be given as command line arguments or as a comma separated
 list of file for the LogFile configuration directive. By default SquidAnalyer will

--- a/etc/squidanalyzer.conf
+++ b/etc/squidanalyzer.conf
@@ -140,6 +140,12 @@ TopUrlUser	10
 # Feel free to define your own header but take care to not break current design.
 #CustomHeader	<a href="http://my.isp.dom/"><img src="http://my.isp.dom/logo.png" title="My ISP link" border="0" width="100" height="110"></a> My ISP Company
 
+# This directive allow you to replace the HTML page title by your custom title
+# The default value is defined as follow:
+# SquidAnalyzer $VERSION Report
+# Feel free to define your own title but take care to not break current design.
+#CustomTitle	My ISP Company Report
+
 # This directive allow exclusion of some unwanted methods in report statistics
 # like HEAD, POST, CONNECT, etc. Can be a comma separated list of methods.
 #ExcludedMethods	HEAD

--- a/squid-analyzer
+++ b/squid-analyzer
@@ -7,6 +7,7 @@ use SquidAnalyzer;
 use Getopt::Long qw(:config no_ignore_case bundling);
 use Benchmark;
 use POSIX ":sys_wait_h";
+use Time::Local;
 
 $| = 1;
 
@@ -30,6 +31,9 @@ my $no_week_stat = 0;
 my $t0 = Benchmark->new;
 my $start_time = '';
 my $stop_time = '';
+my $start_date = '';
+my $stop_date = '';
+my $outputdir = '';
 
 # get the command line parameters
 my $result = GetOptions (
@@ -39,6 +43,7 @@ my $result = GetOptions (
 	"h|help"               => \$help,
 	"j|jobs=i"             => \$queue_size,
 	"l|logfile"            => \$obsolete,
+	"o|outputdir=s"        => \$outputdir,
 	"p|preserve=i"         => \$preserve,
 	"P|pid_dir=s"          => \$pid_dir,
 	"r|rebuild!"           => \$rebuild,
@@ -48,6 +53,8 @@ my $result = GetOptions (
 	"v|version!"           => \$version,
 	"no-year-stat!"        => \$no_year_stat,
 	"no-week-stat!"        => \$no_week_stat,
+	"startdate=s"          => \$start_date,
+	"stopdate=s"           => \$stop_date,
 ); 
 
 # Show warning for obsolete options
@@ -75,6 +82,14 @@ if ($start_time && $start_time !~ /^[0-2]\d:[0-5]\d$/) {
 if ($stop_time && $stop_time !~ /^[0-2]\d:[0-5]\d$/) {
 	die("FATAL: bad format on stop time, must be HH:MM.\n");
 }
+if ($start_date && $start_date !~ /^\d{4}[-\\\/]?[0-1]\d[-\\\/]?[0-3]\d\s*[0-2]\d[-:]?[0-5]\d[-:]?[0-5]\d$/) {
+	die("FATAL: bad format on start date, must be YYYYMMDDHHMMSS.\n");
+}
+$start_date =~ s/[-\\\/:\s]//g if ($start_date);
+if ($stop_date && $stop_date !~ /^\d{4}[-\\\/]?[0-1]\d[-\\\/]?[0-3]\d\s*[0-2]\d[-:]?[0-5]\d[-:]?[0-5]\d$/) {
+	die("FATAL: bad format on stop date, must be YYYYMMDDHHMMSS.\n");
+}
+$stop_date =~ s/[-\\\/:\s]//g if ($stop_date);
 
 # Add multiple log files given from command line
 foreach my $f (@ARGV) {
@@ -109,6 +124,33 @@ $sa->{no_week_stat} = $no_week_stat;
 $sa->{queue_size} = $queue_size;
 $sa->{TimeStart} = $start_time;
 $sa->{TimeStop} = $stop_time;
+
+# Set start and end time (for custom date range reports)
+if ($start_date && $start_date =~ /^(\d{4})(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)/) {
+	my $t = timelocal($6, $5, $4, $3, $2-1, $1);
+	$sa->{report_starttime} = POSIX::strftime("%a %b %e %H:%M:%S %Y", localtime($t));
+	--$t; # 1 second less
+	$sa->{history_time} = $sa->{sg_history_time} = $sa->{ug_history_time} = "$t.999";
+	print STDERR "DEBUG: report start time set to $sa->{report_starttime}\n" if ($debug);
+}
+if ($stop_date && $stop_date =~ /^(\d{4})(\d\d)(\d\d)(\d\d)(\d\d)(\d\d)/) {
+	my $t = timelocal($6, $5, $4, $3, $2-1, $1);
+	$sa->{report_endtime} = POSIX::strftime("%a %b %e %H:%M:%S %Y", localtime($t));
+	$sa->{history_endtime} = "$t.999";
+	print STDERR "DEBUG: report end time set to $sa->{report_endtime}\n" if ($debug);
+}
+
+# Set output directory
+if ($outputdir) {
+	die "ERROR: Invalid output directory name specified\n" if ($outputdir !~ /^[-\w\/]+$/);
+	$outputdir = "$sa->{Output}/$outputdir" if ($outputdir !~ /^\//);
+	if (! -e $outputdir) {
+		mkdir ($outputdir) || die "ERROR: can't create directory $outputdir, $!\n";
+	}
+	$sa->{Output} = $outputdir;
+	print STDERR "DEBUG: Output directory set to $outputdir\n" if ($debug);
+}
+
 
 # Die cleanly on signal
 sub terminate
@@ -146,6 +188,7 @@ sub terminate
 $SIG{'INT'} = \&terminate;
 $SIG{'TERM'} = \&terminate;
 $SIG{'CHLD'} = 'DEFAULT';
+$SIG{'HUP'} = 'IGNORE'; # don't die on HUP
 
 my $t1;
 # Run parsing only if we have a log file or that we are not in rebuild mode
@@ -166,7 +209,7 @@ if ($preserve) {
 # In rebuild mode history time is not use and we must store the
 # specific rebuild date if any is provided at command line.
 if ($rebuild) {
-	$sa->{history_time} = '';
+	$sa->{history_time} = $sa->{sg_history_time} = $sa->{ug_history_time} = '';
 	$sa->{build_date} = $build_date;
 }
 
@@ -202,6 +245,8 @@ Usage: squid-analyzer [ -c squidanalyzer.conf ] [logfile(s)]
     -h | --help                : show this message and exit.
     -j | --jobs number         : number of jobs to run at same time. Default
                                  is 1, run as single process.
+    -o | --outputdir name      : set output directory. If it does not start
+				 with / then prefixes Output from configfile
     -p | --preserve number     : used to set the statistic obsolescence in
 				 number of month. Older stats will be removed.
     -P | --pid_dir directory   : set directory where pid file will be stored.
@@ -218,6 +263,8 @@ Usage: squid-analyzer [ -c squidanalyzer.conf ] [logfile(s)]
     --no-year-stat             : disable years statistics, reports will start
                                  from month level only.
     --no-week-stat             : disable weekly statistics.
+    --startdate YYYYMMDDHHMMSS : log lines before this date and time will not be parsed.
+    --stopdate  YYYYMMDDHHMMSS : log lines after this date and time will not be parsed.
 
 Log files to parse can be given as command line arguments or as a comma separated
 list of file for the LogFile configuration directive. By default SquidAnalyer will


### PR DESCRIPTION
1. Add feature to mention date range for reports.
Sometimes one may need reports for a specific period. The above feature does exactly that. Date range can be specified as YYYY/MM/DD HH:MM:SS or simply YYYYMMDDHHMMSS too.

2. Add feature to mention a different output directory.
This allows reports for specific date range (as per 1 above) to be stored elsewhere instead of main directory.

3. Add feature to have CustomTitle just like CustomHeader.
Squidanalyzer allows to change CustomHeader but does not allows to change Page title. This feature makes it consistent. So that administrator can have Header and Title look same.

4. Ignore SIGHUP signal too.
If you run squidanalyzer over huge log file and switch it to background and then logout of your terminal then SIGHUP is sent to squidanalyzer - killing the background squidanalyzer process. This stops it.

Also if you call Squidanalyzer via CGI (Apache server/web browser) and if end user stops page loading in the browser. Then Apache sends SIGHUP which kills Squidanalyzer abruptly. This stops it.

Overall its better to ignore SIGHUP to avoid unexpected / incomplete results.

5. Some bug fixes and optimization.
There were minor bugs which are fixed. Also some unnecessary checks have been removed to run code slightly faster.