### PR TITLE
SquidAnalyzer.pm can read compressed stat_code.dat files, we can install SquidAnalyzer.pm into custom path, hungarian translation

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Revision history for SquidAnalyzer
 szaszg
     * SquidAnalyzer.pm can read compressed 'stat_code.dat', so you can compress previous years .dat files (e.g.: find 2023 -iname '*.dat' | xargs xz -9).
     * You can install SquidAnalyzer.pm into custom LIB directory, so you can keep all files together (e.g. /opt/squidanalyzer)
+    * Hungarian translation added (hu_HU.txt)
 
 6.6 - Sun May  7 16:38:14 CEST 2017
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 Revision history for SquidAnalyzer
 
+szaszg
+    * SquidAnalyzer.pm can read compressed 'stat_code.dat', so you can compress previous years .dat files (e.g.: find 2023 -iname '*.dat' | xargs xz -9).
+    * You can install SquidAnalyzer.pm into custom LIB directory, so you can keep all files together (e.g. /opt/squidanalyzer)
+
 6.6 - Sun May  7 16:38:14 CEST 2017
 
 This is a maintenance release that fix one year of issues reported by users.

--- a/MANIFEST
+++ b/MANIFEST
@@ -27,4 +27,5 @@ lang/es_ES.txt
 lang/ru_RU.txt
 lang/uk_UA.txt
 lang/cs_CZ.txt
+lang/hu_HU.txt
 META.yml                                 Module meta-data (added by MakeMaker)

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -4,7 +4,7 @@ use ExtUtils::MakeMaker;
 
 use strict;
 
-my @ALLOWED_ARGS = ('LOGFILE','BINDIR','ETCDIR', 'CONFDIR','HTMLDIR','BASEURL','DOCDIR','MANDIR','QUIET','INSTALLDIRS','DESTDIR');
+my @ALLOWED_ARGS = ('LOGFILE','BINDIR','ETCDIR', 'CONFDIR','HTMLDIR','BASEURL','DOCDIR','MANDIR','QUIET','INSTALLDIRS','DESTDIR', 'LIB');
 
 # Parse command line arguments and store them as environment variables
 while ($_ = shift) {
@@ -32,6 +32,7 @@ my $DOCDIR = $ENV{DOCDIR} || '';
 my $MANDIR = $ENV{MANDIR} || '/usr/local/man/man3';
 my $DESTDIR = $ENV{DESTDIR} || '';
 my $INSTALLDIRS = $ENV{INSTALLDIRS} ||= 'site';
+my $LIB = $ENV{LIB} || '';
 
 unless(open(INST, ">install_all.sh")) {
         print "\nError: can't write post install file install_all.sh, $!\n";
@@ -130,6 +131,8 @@ close(INST);
 `perl -p -i -e 's#^Exclude.*#Exclude	$ETCDIR/excluded#' etc/squidanalyzer.conf`;
 `perl -p -i -e 's#^Include.*#Include	$ETCDIR/included#' etc/squidanalyzer.conf`;
 `perl -p -i -e 's#Lang.*\.txt#Lang	$ETCDIR/lang/en_US.txt#' etc/squidanalyzer.conf`;
+`perl -p -i -e 's|^use lib .*|#use lib "PERL5LIB"|' squid-analyzer`;
+`perl -p -i -e 's|^\#use lib .*|use lib "$LIB"|' squid-analyzer` if $LIB ne '';
 
 my $zcat = `which zcat`;
 chomp($zcat);
@@ -158,6 +161,7 @@ WriteMakefile(
 	'MAN3PODS'     => { 'doc/SquidAnalyzer.pod' => 'blib/man3/SquidAnalyzer.3pm' },
 	'DESTDIR'      => $DESTDIR,
 	'INSTALLDIRS'  => $INSTALLDIRS,
+	'LIB'          => $LIB,
 	'clean'	       => { FILES => "install_all.sh lib/blib/ squid-analyzer.3" },
 	'META_MERGE'   => {
 		resources  => {

--- a/README
+++ b/README
@@ -21,8 +21,11 @@ REQUIREMENT
     browser side without extra installation required.
 
 CHANGES from https://github.com/darold/squidanalyzer
-    SquidAnalyzer.pm can read compressed 'stat_code.dat', so you can compress previous years .dat files (e.g.: find 2023 -iname '*.dat' | xargs xz -9).
-    You can install SquidAnalyzer.pm into custom LIB directory, so you can keep all files together (e.g. /opt/squidanalyzer)
+    SquidAnalyzer.pm can read compressed 'stat_code.dat', so you can compress
+    previous years .dat files (e.g.: find 2023 -iname '*.dat' | xargs xz -9).
+    You can install SquidAnalyzer.pm into custom LIB directory, so you can
+    keep all files together (e.g. /opt/squidanalyzer)
+    Hungarian translation
 
 INSTALLATION
   Generic install

--- a/README
+++ b/README
@@ -20,6 +20,10 @@ REQUIREMENT
     are based on the Flotr2 Javascript library so they are drawn at your
     browser side without extra installation required.
 
+CHANGES from https://github.com/darold/squidanalyzer
+    SquidAnalyzer.pm can read compressed 'stat_code.dat', so you can compress previous years .dat files (e.g.: find 2023 -iname '*.dat' | xargs xz -9).
+    You can install SquidAnalyzer.pm into custom LIB directory, so you can keep all files together (e.g. /opt/squidanalyzer)
+
 INSTALLATION
   Generic install
     If you want the package to be installed into the Perl distribution just
@@ -70,13 +74,25 @@ INSTALLATION
                     MANDIR=/usr/share/man/man3 \
                     DOCDIR=/usr/share/doc/squidanalyzer
 
+    Or you can install everything into one directory (e.g.: /opt/squidanalyzer)
+
+            perl Makefile.PL \
+                    LOGFILE=/var/log/squid/access.log \
+                    BINDIR=/opt/squidanalyzer/bin \
+                    CONFDIR=/opt/squidanalyzer/etc \
+                    HTMLDIR=/var/www/squidreport \
+                    BASEURL=/squidreport \
+                    MANDIR=/opt/squidanalyzer/share/man/man3 \
+                    DOCDIR=/opt/squidanalyzer/share/doc/squidanalyzer
+                    LIB=/opt/squidanalyzer/lib
+
     If you want to build a distro package, there are two other options that
     you may use. The QUIET option is to tell to Makefile.PL to not show the
     default post install README. The DESTDIR is to create and install all
     files in a package build base directory. For example for Fedora RPM,
     thing may look like that:
 
-            # Make Perl and SendmailAnalyzer distrib files
+            # Make Perl and SquidAnalyzer distrib files
             %{__perl} Makefile.PL \
                 INSTALLDIRS=vendor \
                 QUIET=1 \

--- a/SquidAnalyzer.pm
+++ b/SquidAnalyzer.pm
@@ -1142,6 +1142,25 @@ sub check_inclusions
 	return 0;
 }
 
+sub _open_file_read_compressed
+{
+	my ($self, $file, $filename) = @_;
+	print STDERR "DEBUG: _open_file_read_compressed($filename).\n" if (!$self->{QuietMode});
+	if (-e $filename.'.gz') {
+		# Open a pipe to zcat program for compressed log
+		$file->open("$ZCAT_PROG $filename.gz |") || return 0;
+	} elsif (-e $filename.'.bz2') {
+		# Open a pipe to bzcat program for compressed log
+		$file->open("$BZCAT_PROG $filename.bz2 |") || return 0;
+	} elsif (-e $filename.'.xz') {
+		# Open a pipe to xzcat program for compressed log
+		$file->open("$XZCAT_PROG $filename.xz |") || return 0;
+	} else {
+		$file->open($filename) || return 0;
+	}
+	return 1;
+}
+
 sub _parse_file_part
 {
 	my ($self, $file, $start_offset, $stop_offset) = @_;
@@ -6079,7 +6098,7 @@ sub _gen_summary
 	foreach my $d (@dirs) {
 		# Load code statistics
 		my $infile = new IO::File;
-		$infile->open("$outdir/$d/stat_code.dat") || return;
+		$self->_open_file_read_compressed($infile, "$outdir/$d/stat_code.dat") || return;
 		while (my $l = <$infile>) {
 			chomp($l);
 			my ($code, $data) = split(/\s/, $l);

--- a/doc/SquidAnalyzer.pod
+++ b/doc/SquidAnalyzer.pod
@@ -76,6 +76,18 @@ Makefile.PL Perl script. Here is a sample:
 		MANDIR=/usr/share/man/man3 \
 		DOCDIR=/usr/share/doc/squidanalyzer
 
+Or you can install everything into one directory (e.g.: /opt/squidanalyzer)
+
+	perl Makefile.PL \
+		LOGFILE=/var/log/squid/access.log \
+		BINDIR=/opt/squidanalyzer/bin \
+		CONFDIR=/opt/squidanalyzer/etc \
+		HTMLDIR=/var/www/squidreport \
+		BASEURL=/squidreport \
+		MANDIR=/opt/squidanalyzer/share/man/man3 \
+		DOCDIR=/opt/squidanalyzer/share/doc/squidanalyzer
+		LIB=/opt/squidanalyzer/lib
+
 If you want to build a distro package, there are two other options that you may use. The QUIET option is to tell to Makefile.PL to not show the default post install README. The DESTDIR is to create and install all files in a package build base directory. For example for Fedora RPM, thing may look like that:
 
 	# Make Perl and SendmailAnalyzer distrib files

--- a/etc/squidanalyzer.conf
+++ b/etc/squidanalyzer.conf
@@ -101,7 +101,7 @@ Exclude	/etc/squidanalyzer/excluded
 Include	/etc/squidanalyzer/included
 
 # Translation Lang	/etc/squidanalyzer/lang/en_US.txt,
-# en_US.txt, ru_RU.txt, uk_UA.txt, cs_CZ.txt, pl_PL.txt and de_DE.txt).
+# en_US.txt, ru_RU.txt, uk_UA.txt, cs_CZ.txt, pl_PL.txt, hu_HU.txt and de_DE.txt).
 # Default to:
 #Lang	/etc/squidanalyzer/lang/en_US.txt
 

--- a/lang/hu_HU.txt
+++ b/lang/hu_HU.txt
@@ -1,0 +1,119 @@
+#------------------------------------------------------------------------------
+# This is the translation file of SquidAnalyzer program. The first column
+# represente the program access key to translated string and the second
+# column is the translated string itself.
+# Keys should not be modified and are case sensitive. The column separator
+# is the tabulation character.
+#
+# Specials tags %s and %d in the translated string are uses by the program to
+# replace dynamics values. Following the language their place in the string
+# may vary.
+#
+# Author: Gilles Darold
+#------------------------------------------------------------------------------
+CharSet				utf-8
+01				Jan
+02				Febr
+03				Márc
+04				Ápr
+05				Máj
+06				Jún
+07				Júl
+08				Aug
+09				Szept
+10				Okt
+11				Nov
+12				Dec
+KB				Kilobytes
+MB				Megabytes
+GB				Gigabytes
+Requests			Kérés
+Bytes				Bytes
+Megabytes			Megabytes
+Total				Összesen
+Years				Évek
+Months				Hónapok
+Days				Napok
+Hit				Találat
+Miss				Letöltött
+Denied				Visszautasított
+Cost				Érték
+Users				Felhasználók
+Sites				Oldalak
+Domains				Domain nevek
+Requests_graph			Kérések
+Megabytes_graph			Megabyte-ok
+Months_graph			Hónapok
+Days_graph			Napok
+Hit_graph			Találat
+Miss_graph			Letöltött
+Denied_graph			Visszautasított
+Total_graph			Mindösszesen
+Domains_graph			Domain nevek
+Users_help			Felhasználók teljes száma erre az időszakra
+Sites_help			Meglátogatott oldalak teljes száma erre az időszakra
+Domains_help			Meglátogatott második szintű domain nevek teljes száma erre az időszakra
+Hit_help			Oldalak, képek, stb. amit megtalált a gyorsítótárban
+Miss_help			Oldalak, képek, stb. amit nem talált meg a gyorsítótárban
+Denied_help			Oldalak, képek, stb. amit visszautasított
+Cost_help			1 Megabyte =
+Generation			A kimutatás -
+Main_cache_title		Cache statisztika
+Cache_title			Cache statisztika -
+Stat_label			Stat
+Mime_link			Mime típusok
+Network_link			Hálózatok
+User_link			Felhasználók
+Top_url_link			Leggyakoribb url-ek
+Top_domain_link			Leggyakoribb domain nevek
+Back_link			Vissza
+Graph_cache_hit_title		%s kérés statisztika -
+Graph_cache_byte_title		%s Megabyte-ok statisztika -
+Hourly				Óránként
+Hours				Órák
+Daily				Napi
+Days				Napok
+Monthly				Havi
+Months				Hónapok
+Mime_title			Mime típusok statisztika -
+Mime_number			Mime típusok száma
+Network_title			Hálózatok statisztikája -
+Network_number			Hálózatok száma
+Duration			Időtartam
+Time				Idő
+Largest				Legnagyobb
+Url				Url
+User_title			Felhasználói statisztika -
+User_number			Felhasználók száma
+Url_title			Első %d oldal
+Url_Hits_title			Első %d url találat -
+Url_Bytes_title			Első %d url byte-ok -
+Url_Duration_title		Első %d url időtartam -
+Url_number			Url-ek száma
+Domain_Hits_title		Első %d domain találat -
+Domain_Bytes_title		Első %d Domain byte-ok -
+Domain_Duration_title		Első %d Domain időtartam on
+Domain_number			Domain-ek száma
+Domain_graph_hits_title		Domain találatok statisztika -
+Domain_graph_bytes_title	Domain byte-ok statisztika -
+Second_domain_graph_hits_title	Második szintű találatok statisztika -
+Second_domain_graph_bytes_title	Második szintű byte statisztika -
+First_visit			Első látogatás
+Last_visit			utolsó látogatás
+Globals_Statistics		Mindösszesen statisztikák
+Legend				Magyarázat
+File_Generated			File készült
+Up_link				Fel
+Click_year_stat			Kattintson az éves statisztikák link-re a részletekért
+Mime_graph_hits_title		Mime típusok találat statisztika -
+Mime_graph_bytes_title		Mime típusok MByte-ok statisztika -
+User				Felhasználó
+Count				Darabszám
+WeekDay				Va Hé Ke Sze Csü Pé Szo
+Week				Hét
+Top_denied_link			Legtöbbet visszautasított
+Blocklist_acl_title		Használt tiltólisták (ACL)
+Throughput			Átviteli sebesség
+Graph_throughput_title		%s átviteli sebesség -
+Throughput_graph		Bytes/sec
+User_Ip				Felhasználó IP címe

--- a/squid-analyzer
+++ b/squid-analyzer
@@ -2,6 +2,7 @@
 #
 # Perl frontend to SquidAnalyzer.pm.
 #
+#use lib "PERL5LIB"
 use strict;
 use SquidAnalyzer;
 use Getopt::Long qw(:config no_ignore_case bundling);


### PR DESCRIPTION
If we compress older .dat files (to free up a lot of space) SquidAnalyzer.pm cannot read compressed stat_code.dat files and does not update index.html

`SquidAnalyzer.pm`
- new sub _open_file_read_compressed
- in _gen_summary we use $self->_open_file_read_compressed() to open 'code_stat.dat{.gz,bz2,xz}' files

SquidAnalyzer.pm always installed into SITEPREFIX/PERLLIB directory (e.g. /usr/local/perl/5.nn.nnn) even we install everything into e.g. /opt/squidanalyzer

`Makefile.PL`
- add LIB to @ALLOWED_ARGS list
- replace use lib '' placeholder to LIB path in squid-analyzer
- use LIB in WriteMakefile()

`squid-analyzer`
- add use lib '...' placeholder

`README`, `doc/SquidAnalyzer.pod`
- add example install for LIB usage
into custom path, hungarian translation

Hungarian translation
